### PR TITLE
Remove peer dependency on ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -425,7 +425,7 @@ schemars = { version = "~0" }
 serde = { version = "~1" }
 serde_json = { version = "~1" }
 k8s-openapi = { version = "~0" }
-kube = { version = "~0", features = ["derive"] }
+kube = { version = "~0", default-features = false, features = ["derive"] }
 
 [profile.dev]
 # Disable settings to speeds up builds


### PR DESCRIPTION
The `kube` crate pulls in `ring` by default through `kube-client`. This disables that behavior while also slimming the dependencies.